### PR TITLE
PANDARIA: Fix show unauthorized when group member to get the monitor data

### DIFF
--- a/pkg/agent/listener.go
+++ b/pkg/agent/listener.go
@@ -11,9 +11,13 @@ import (
 	"golang.org/x/net/http2/hpack"
 )
 
+/* PANDARIA: Fix get request head X-RANCHER-GROUP is nil.
+we need to be aware that keys are canonicalized header["X-Rancher-Group"] will be work, but header["X-RANCHER-GROUP"] will not return any value.
+Details view https://github.com/golang/go/issues/34799
+*/
 const (
-	rancherUserHeaderKey   = "X-RANCHER-USER"
-	rancherGroupHeaderKey  = "X-RANCHER-GROUP"
+	rancherUserHeaderKey   = "X-Rancher-User"
+	rancherGroupHeaderKey  = "X-Rancher-Group"
 	authorizationHeaderKey = "Authorization"
 )
 


### PR DESCRIPTION
在通过方式 ` r.Header["Key"] ` 获取请求头数组时key需要遵循大驼峰的规范，否则返回的为nil

具体查看 https://github.com/golang/go/issues/34799

golang 1.14 开始支持  r.Header.Values(key string) 方法获取请求头 map 对应的数组，但是当前 repo 还是golang 1.13。所以暂时修改 key `X-RANCHER-GROUP` 的命名

**Relate issue：**
https://github.com/cnrancher/pandaria/issues/1187